### PR TITLE
Lock npm versions so Narrative works out of the box

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -153,6 +153,19 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
+    "jquery": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+    },
+    "jquery-validation": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.19.0.tgz",
+      "integrity": "sha512-i1ygcs9K9eI0jqQ8fiOZdT0Ofw941YII1zyPQDUkBS8t2G8SoSWz8UUEVT6gV1KvsaBbovtL8YxjLALACR0syQ==",
+      "requires": {
+        "jquery": "^1.7 || ^2.0 || ^3.1"
+      }
+    },
     "keypress": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,375 @@
+{
+  "name": "MyNarrative",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "bson": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+      "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
+    },
+    "buffer-crc32": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
+      "integrity": "sha1-vj5TgvwCttYySVasGvmKqYsIU0w="
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
+    "bytes": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.0.tgz",
+      "integrity": "sha1-qtM+wU49wsp06OfUUfm6BTrU96A="
+    },
+    "commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "optional": true
+    },
+    "connect": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-2.9.0.tgz",
+      "integrity": "sha1-7PR4tvJyPnLPmhnRx9GdCze1N0Y=",
+      "requires": {
+        "buffer-crc32": "0.2.1",
+        "bytes": "0.2.0",
+        "cookie": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "multiparty": "2.1.8",
+        "pause": "0.0.1",
+        "qs": "0.6.5",
+        "send": "0.1.4",
+        "uid2": "0.0.2"
+      }
+    },
+    "cookie": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
+      "integrity": "sha1-kOtGndzpBchm3mh+/EMTHYgB+dA="
+    },
+    "cookie-signature": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz",
+      "integrity": "sha1-ROByFIrwHm6OJK+/EmkNaK5pjss="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "es6-promise": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
+    },
+    "express": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-3.4.0.tgz",
+      "integrity": "sha1-btKJ2g1fVawwmXz4MuX8NveEBx4=",
+      "requires": {
+        "buffer-crc32": "0.2.1",
+        "commander": "1.2.0",
+        "connect": "2.9.0",
+        "cookie": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "mkdirp": "0.3.5",
+        "range-parser": "0.0.4",
+        "send": "0.1.4"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-1.2.0.tgz",
+          "integrity": "sha1-/VcTv6FTx9bMWZN4patMRcU1Ap4=",
+          "requires": {
+            "keypress": "0.1.x"
+          }
+        }
+      }
+    },
+    "foreachasync": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
+      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
+    },
+    "fresh": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz",
+      "integrity": "sha1-v9lALPPfEsSkwxDHn5mj3eE9NKc="
+    },
+    "handlebars": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.13.tgz",
+      "integrity": "sha512-uydY0jy4Z3wy/iGXsi64UtLD4t1fFJe16c/NFxsYE4WdQis8ZCzOXUZaPQNG0e5bgtLQV41QTfqBindhEjnpyQ==",
+      "requires": {
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "hbs": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/hbs/-/hbs-4.0.3.tgz",
+      "integrity": "sha512-u8AAbtYUWqNATGEruLdlyAbN+lOtKED+mn38t/13ZkeaKy5BObknFuL1Gtmj0QwXgcSizQ68FHOP1ZST/HP+dg==",
+      "requires": {
+        "handlebars": "4.0.13",
+        "walk": "2.3.9"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "keypress": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "methods": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz",
+      "integrity": "sha1-J3yQ+L7zlwlkWoNxxRw7bGSOBow="
+    },
+    "mime": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+    },
+    "mongodb": {
+      "version": "2.2.36",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.36.tgz",
+      "integrity": "sha512-P2SBLQ8Z0PVx71ngoXwo12+FiSfbNfGOClAao03/bant5DgLNkOPAck5IaJcEk4gKlQhDEURzfR3xuBG1/B+IA==",
+      "requires": {
+        "es6-promise": "3.2.1",
+        "mongodb-core": "2.1.20",
+        "readable-stream": "2.2.7"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+          "requires": {
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "mongodb-core": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.20.tgz",
+      "integrity": "sha512-IN57CX5/Q1bhDq6ShAR6gIv4koFsZP7L8WOK1S0lR0pVDQaScffSMV5jxubLsmZ7J+UdqmykKw4r9hG3XQEGgQ==",
+      "requires": {
+        "bson": "~1.0.4",
+        "require_optional": "~1.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "multiparty": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-2.1.8.tgz",
+      "integrity": "sha1-NaMYNDI1eO5l9dhwVoCXkUc5z04=",
+      "requires": {
+        "readable-stream": "~1.0.2",
+        "stream-counter": "~0.1.0"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "qs": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz",
+      "integrity": "sha1-KUsmjksNQlD23eGbO4s0k13/FO8="
+    },
+    "range-parser": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz",
+      "integrity": "sha1-wEJ//vUcEKy6B4KkbJYC50T/Ygs="
+    },
+    "readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      }
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+    },
+    "send": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
+      "integrity": "sha1-vnDY0b4B3mGCGvE3gLUDRaT3Gr0=",
+      "requires": {
+        "debug": "*",
+        "fresh": "0.2.0",
+        "mime": "~1.2.9",
+        "range-parser": "0.0.4"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "stream-counter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.1.0.tgz",
+      "integrity": "sha1-oDXkKTYftX82Fgbhf82Ki5Z3Mns=",
+      "requires": {
+        "readable-stream": "~1.0.2"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "uglify-js": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.3.tgz",
+      "integrity": "sha512-rIQPT2UMDnk4jRX+w4WO84/pebU2jiLsjgIyrCktYgSvx28enOE3iYQMr+BD1rHiitWnDmpu0cY/LfIEpKcjcw==",
+      "optional": true,
+      "requires": {
+        "commander": "~2.19.0",
+        "source-map": "~0.6.1"
+      }
+    },
+    "uid2": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.2.tgz",
+      "integrity": "sha1-EH+xVcgsETZiB5ftTIjPKwj2qrg="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "walk": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
+      "integrity": "sha1-MbTbZnjyrgHDnqn7hyWpAx5Vins=",
+      "requires": {
+        "foreachasync": "^3.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "express": "= 3.4.0",
     "mongodb": "^2.2.33",
-    "hbs": ">= 2.4.0"
+    "hbs": ">= 2.4.0",
+    "jquery-validation": "^1.19.0"
   },
   "engine": ">= 0.10.18",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   "keywords": [
     "narrative"
   ],
-  "dependencies" : {
-    "express": ">= 3.4.0",
-    "mongodb": ">= 1.3.19",
+  "dependencies": {
+    "express": "= 3.4.0",
+    "mongodb": "^2.2.33",
     "hbs": ">= 2.4.0"
   },
   "engine": ">= 0.10.18",

--- a/views/home.hbs
+++ b/views/home.hbs
@@ -137,7 +137,6 @@
     <script src="js/sidemenu.js"></script>
     <script src="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
     <script src="js/narrative.js"></script>
-    <script src="assets/js/jquery.validate.min.js"></script>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
     <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
As of right now, the error in #1 prevents the app from running after a clean clone. There's a similar error in the MongoDB versioning after fixing that one. This PR just locks the `package.json` file to previous versions (assumedly those originally used) so `node app` actually starts the app as the README suggests. :+1: 

This also includes a jquery.validate npm package since one was being required in the view but not actually included in the repo. I'm not very familiar with Node so I'm not actually sure if this is the right approach (or what it's used for), but it's a start.